### PR TITLE
feat: replace WhatsApp Meta API with Baileys bridge

### DIFF
--- a/.claude/skills/whatsapp/SKILL.md
+++ b/.claude/skills/whatsapp/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: whatsapp
+description: Send and receive WhatsApp messages, media, polls, reactions, and manage groups via the Baileys bridge. Use when the user mentions WhatsApp, wants to message someone, or manage WhatsApp groups.
+---
+
+# WhatsApp — Baileys Bridge
+
+Full WhatsApp capability via direct WhatsApp Web protocol (Baileys).
+The bridge runs at `http://localhost:3100`. Use `curl` via Bash to call it.
+
+## JID Formats
+
+| Type | Format | Example |
+|------|--------|---------|
+| Individual | `<number>@s.whatsapp.net` | `34612345678@s.whatsapp.net` |
+| Group | `<id>@g.us` | `120363012345678901@g.us` |
+
+The `to` field auto-converts phone numbers like `+34612345678` to JIDs.
+For reactions/edit/unsend, use the full JID.
+
+---
+
+## Messaging
+
+### Send Text
+```bash
+curl -s -X POST http://localhost:3100/send/text \
+  -H 'Content-Type: application/json' \
+  -d '{"to": "+34612345678", "message": "Hello!"}'
+```
+
+### Reply / Quote a Message
+```bash
+curl -s -X POST http://localhost:3100/send/text \
+  -H 'Content-Type: application/json' \
+  -d '{"to": "+34612345678", "message": "Replying!", "quotedId": "MSG_ID_HERE"}'
+```
+
+### Send Image / Video / Document
+```bash
+curl -s -X POST http://localhost:3100/send/media \
+  -H 'Content-Type: application/json' \
+  -d '{"to": "+34612345678", "filePath": "/path/to/photo.jpg", "caption": "Check this out"}'
+```
+Supported: JPG, PNG, MP4, PDF, DOC, any file type.
+
+### Send Voice Note
+```bash
+curl -s -X POST http://localhost:3100/send/media \
+  -H 'Content-Type: application/json' \
+  -d '{"to": "+34612345678", "filePath": "/path/to/audio.ogg", "asVoice": true}'
+```
+**Critical:** Voice notes MUST be OGG/Opus format. Convert first:
+```bash
+ffmpeg -i input.wav -c:a libopus -b:a 64k output.ogg
+```
+
+### Send GIF
+```bash
+curl -s -X POST http://localhost:3100/send/media \
+  -H 'Content-Type: application/json' \
+  -d '{"to": "+34612345678", "filePath": "/path/to/animation.mp4", "gifPlayback": true}'
+```
+WhatsApp requires MP4 for GIFs. Convert first:
+```bash
+ffmpeg -i input.gif -movflags faststart -pix_fmt yuv420p -vf "scale=trunc(iw/2)*2:trunc(ih/2)*2" output.mp4 -y
+```
+
+### Send Sticker
+```bash
+curl -s -X POST http://localhost:3100/send/sticker \
+  -H 'Content-Type: application/json' \
+  -d '{"to": "+34612345678", "filePath": "/path/to/sticker.webp"}'
+```
+Must be WebP format, ideally 512×512. Convert:
+```bash
+ffmpeg -i input.png -vf "scale=512:512:force_original_aspect_ratio=decrease,pad=512:512:(ow-iw)/2:(oh-ih)/2:color=0x00000000" output.webp
+```
+
+### Send Poll
+```bash
+curl -s -X POST http://localhost:3100/send/poll \
+  -H 'Content-Type: application/json' \
+  -d '{"to": "+34612345678", "question": "What time works?", "options": ["3pm", "4pm", "5pm"], "selectableCount": 1}'
+```
+`selectableCount`: 0 = multi-select, 1+ = limited select.
+
+---
+
+## Interactions
+
+### React to a Message
+```bash
+curl -s -X POST http://localhost:3100/react \
+  -H 'Content-Type: application/json' \
+  -d '{"chatJid": "34612345678@s.whatsapp.net", "messageId": "MSG_ID", "emoji": "🚀"}'
+```
+
+### Remove a Reaction
+```bash
+curl -s -X POST http://localhost:3100/react \
+  -H 'Content-Type: application/json' \
+  -d '{"chatJid": "34612345678@s.whatsapp.net", "messageId": "MSG_ID", "remove": true}'
+```
+
+### Edit a Sent Message (Own Messages Only)
+```bash
+curl -s -X POST http://localhost:3100/edit \
+  -H 'Content-Type: application/json' \
+  -d '{"chatJid": "34612345678@s.whatsapp.net", "messageId": "MSG_ID", "message": "Updated text"}'
+```
+
+### Unsend / Delete a Message
+```bash
+curl -s -X POST http://localhost:3100/unsend \
+  -H 'Content-Type: application/json' \
+  -d '{"chatJid": "34612345678@s.whatsapp.net", "messageId": "MSG_ID"}'
+```
+
+---
+
+## Group Management
+
+### Create Group
+```bash
+curl -s -X POST http://localhost:3100/group/create \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "Project Team", "participants": ["+34612345678", "+34687654321"]}'
+```
+
+### Rename Group
+```bash
+curl -s -X POST http://localhost:3100/group/rename \
+  -H 'Content-Type: application/json' \
+  -d '{"groupId": "120363012345678901@g.us", "name": "New Name"}'
+```
+
+### Set Group Description
+```bash
+curl -s -X POST http://localhost:3100/group/description \
+  -H 'Content-Type: application/json' \
+  -d '{"groupId": "120363012345678901@g.us", "description": "Team chat for Q1"}'
+```
+
+### Set Group Icon
+```bash
+curl -s -X POST http://localhost:3100/group/icon \
+  -H 'Content-Type: application/json' \
+  -d '{"groupId": "120363012345678901@g.us", "filePath": "/path/to/icon.jpg"}'
+```
+
+### Add / Remove / Promote / Demote Participants
+```bash
+curl -s -X POST http://localhost:3100/group/participants \
+  -H 'Content-Type: application/json' \
+  -d '{"groupId": "120363012345678901@g.us", "participants": ["+34612345678"], "action": "add"}'
+```
+Actions: `add`, `remove`, `promote`, `demote`
+
+### Get Invite Link
+```bash
+curl -s -X POST http://localhost:3100/group/invite-code \
+  -H 'Content-Type: application/json' \
+  -d '{"groupId": "120363012345678901@g.us"}'
+```
+
+### Revoke Invite Link
+```bash
+curl -s -X POST http://localhost:3100/group/revoke-invite \
+  -H 'Content-Type: application/json' \
+  -d '{"groupId": "120363012345678901@g.us"}'
+```
+
+### Get Group Info
+```bash
+curl -s http://localhost:3100/group/info/120363012345678901@g.us
+```
+Returns: name, description, participants, admins, creation date.
+
+### Leave Group
+```bash
+curl -s -X POST http://localhost:3100/group/leave \
+  -H 'Content-Type: application/json' \
+  -d '{"groupId": "120363012345678901@g.us"}'
+```
+
+---
+
+## Confirmation
+
+Always confirm before: sending messages to new contacts, unsending messages, removing participants, leaving groups, revoking invite links. One sentence: "Ready — confirm?"
+
+## Rate Limits
+
+WhatsApp has anti-spam measures. Never:
+- Bulk-message many contacts
+- Rapid-fire messages
+- Message contacts who haven't messaged first
+
+## Message IDs
+
+Needed for reactions, edit, unsend. Inbound messages include the ID in the event payload. Sent message responses return the ID in `{"success": true, "id": "..."}`.
+
+## Media Format Reference
+
+| Type | Format | Notes |
+|------|--------|-------|
+| Voice note | OGG/Opus | `ffmpeg -i input.wav -c:a libopus -b:a 64k output.ogg` |
+| Sticker | WebP 512×512 | `ffmpeg -i input.png -vf "scale=512:512:..." output.webp` |
+| GIF | MP4 | `ffmpeg -i input.gif -movflags faststart ... output.mp4` |
+| Image | JPG/PNG | Native support |
+| Video | MP4 | Native support |
+| Document | Any | Sent as file attachment |

--- a/baileys-bridge/Dockerfile
+++ b/baileys-bridge/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-slim
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY index.js ./
+CMD ["node", "index.js"]

--- a/baileys-bridge/index.js
+++ b/baileys-bridge/index.js
@@ -1,0 +1,379 @@
+/**
+ * Baileys Bridge — WhatsApp Web sidecar for Open Assistant.
+ *
+ * Exposes a REST API that the Python app calls to send messages, media,
+ * reactions, etc.  Inbound messages are forwarded to a configurable
+ * callback URL (the Python webhook).
+ *
+ * Auth: QR code printed to terminal on first run; session persisted to disk.
+ */
+
+import makeWASocket, {
+  DisconnectReason,
+  fetchLatestBaileysVersion,
+  makeCacheableSignalKeyStore,
+  useMultiFileAuthState,
+} from "@whiskeysockets/baileys";
+import express from "express";
+import fs from "fs";
+import pino from "pino";
+import qrcode from "qrcode-terminal";
+
+// ── Config ──────────────────────────────────────────────────────────────────
+const PORT = parseInt(process.env.BAILEYS_PORT || "3100", 10);
+const CALLBACK_URL = process.env.BAILEYS_CALLBACK_URL || "http://localhost:8080/webhook/whatsapp/baileys";
+const AUTH_DIR = process.env.BAILEYS_AUTH_DIR || "./auth_state";
+const ACK_MESSAGE = process.env.BAILEYS_ACK_MESSAGE || "";
+
+const logger = pino({ level: process.env.LOG_LEVEL || "warn" });
+
+// ── WhatsApp connection ─────────────────────────────────────────────────────
+let sock = null;
+
+async function connectWhatsApp() {
+  const { state, saveCreds } = await useMultiFileAuthState(AUTH_DIR);
+  const { version } = await fetchLatestBaileysVersion();
+
+  sock = makeWASocket.default({
+    version,
+    logger,
+    auth: {
+      creds: state.creds,
+      keys: makeCacheableSignalKeyStore(state.keys, logger),
+    },
+    printQRInTerminal: false,
+    generateHighQualityLinkPreview: true,
+  });
+
+  // QR code for linking
+  sock.ev.on("connection.update", (update) => {
+    const { connection, lastDisconnect, qr } = update;
+
+    if (qr) {
+      console.log("\n╔══════════════════════════════════════╗");
+      console.log("║   Scan this QR code with WhatsApp   ║");
+      console.log("╚══════════════════════════════════════╝\n");
+      qrcode.generate(qr, { small: true });
+    }
+
+    if (connection === "close") {
+      const code = lastDisconnect?.error?.output?.statusCode;
+      if (code !== DisconnectReason.loggedOut) {
+        console.log("Connection lost, reconnecting...");
+        connectWhatsApp();
+      } else {
+        console.log("Logged out. Delete auth_state and restart to re-link.");
+      }
+    }
+
+    if (connection === "open") {
+      console.log("WhatsApp connected!");
+    }
+  });
+
+  sock.ev.on("creds.update", saveCreds);
+
+  // ── Inbound messages → forward to Python ────────────────────────────────
+  sock.ev.on("messages.upsert", async ({ messages, type }) => {
+    if (type !== "notify") return;
+
+    for (const msg of messages) {
+      if (msg.key.fromMe) continue;
+
+      // Instant ack message (like WhatsApp Ultimate's ackMessage)
+      if (ACK_MESSAGE && !msg.key.remoteJid.endsWith("@g.us")) {
+        try {
+          await sock.sendMessage(msg.key.remoteJid, { text: ACK_MESSAGE });
+        } catch (e) {
+          console.error("ack message failed:", e.message);
+        }
+      }
+
+      const payload = {
+        id: msg.key.id,
+        from: msg.key.remoteJid,
+        participant: msg.key.participant || null,
+        pushName: msg.pushName || null,
+        timestamp: msg.messageTimestamp,
+        type: detectMessageType(msg),
+        text: extractText(msg),
+        media: extractMediaInfo(msg),
+        quotedMessage: msg.message?.extendedTextMessage?.contextInfo?.quotedMessage
+          ? { id: msg.message.extendedTextMessage.contextInfo.stanzaId }
+          : null,
+        raw: msg,
+      };
+
+      // Forward to Python callback
+      try {
+        await fetch(CALLBACK_URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+      } catch (e) {
+        console.error("Failed to forward message to callback:", e.message);
+      }
+    }
+  });
+}
+
+function detectMessageType(msg) {
+  const m = msg.message;
+  if (!m) return "unknown";
+  if (m.conversation || m.extendedTextMessage) return "text";
+  if (m.imageMessage) return "image";
+  if (m.videoMessage) return "video";
+  if (m.audioMessage) return m.audioMessage.ptt ? "voice" : "audio";
+  if (m.documentMessage) return "document";
+  if (m.stickerMessage) return "sticker";
+  if (m.pollCreationMessage || m.pollCreationMessageV3) return "poll";
+  if (m.reactionMessage) return "reaction";
+  return "unknown";
+}
+
+function extractText(msg) {
+  const m = msg.message;
+  if (!m) return null;
+  return m.conversation || m.extendedTextMessage?.text || m.imageMessage?.caption || m.videoMessage?.caption || null;
+}
+
+function extractMediaInfo(msg) {
+  const m = msg.message;
+  if (!m) return null;
+  for (const key of ["imageMessage", "videoMessage", "audioMessage", "documentMessage", "stickerMessage"]) {
+    if (m[key]) {
+      return {
+        type: key.replace("Message", ""),
+        mimetype: m[key].mimetype,
+        fileLength: m[key].fileLength,
+        fileName: m[key].fileName || null,
+      };
+    }
+  }
+  return null;
+}
+
+// ── REST API ────────────────────────────────────────────────────────────────
+const app = express();
+app.use(express.json({ limit: "50mb" }));
+
+// Health check
+app.get("/health", (_req, res) => {
+  res.json({ status: sock ? "connected" : "disconnected" });
+});
+
+// Send text message
+app.post("/send/text", async (req, res) => {
+  try {
+    const { to, message, quotedId } = req.body;
+    const jid = toJid(to);
+    const opts = {};
+    if (quotedId) {
+      opts.quoted = { key: { remoteJid: jid, id: quotedId } };
+    }
+    const result = await sock.sendMessage(jid, { text: message }, opts);
+    res.json({ success: true, id: result.key.id });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// Send media (image, video, document, audio)
+app.post("/send/media", async (req, res) => {
+  try {
+    const { to, filePath, caption, mimetype, asVoice, gifPlayback } = req.body;
+    const jid = toJid(to);
+    const buffer = fs.readFileSync(filePath);
+    const ext = filePath.split(".").pop().toLowerCase();
+
+    let msg = {};
+    if (["jpg", "jpeg", "png", "webp"].includes(ext) && !gifPlayback) {
+      msg = { image: buffer, caption, mimetype: mimetype || `image/${ext === "jpg" ? "jpeg" : ext}` };
+    } else if (["mp4", "avi", "mkv"].includes(ext) || gifPlayback) {
+      msg = { video: buffer, caption, mimetype: mimetype || "video/mp4", gifPlayback: !!gifPlayback };
+    } else if (["ogg", "mp3", "wav", "m4a"].includes(ext) || asVoice) {
+      msg = { audio: buffer, mimetype: mimetype || "audio/ogg; codecs=opus", ptt: !!asVoice };
+    } else {
+      msg = { document: buffer, mimetype: mimetype || "application/octet-stream", fileName: filePath.split("/").pop() };
+    }
+
+    const result = await sock.sendMessage(jid, msg);
+    res.json({ success: true, id: result.key.id });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// Send sticker
+app.post("/send/sticker", async (req, res) => {
+  try {
+    const { to, filePath } = req.body;
+    const buffer = fs.readFileSync(filePath);
+    const result = await sock.sendMessage(toJid(to), { sticker: buffer });
+    res.json({ success: true, id: result.key.id });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// Send poll
+app.post("/send/poll", async (req, res) => {
+  try {
+    const { to, question, options, selectableCount } = req.body;
+    const result = await sock.sendMessage(toJid(to), {
+      poll: { name: question, values: options, selectableCount: selectableCount || 0 },
+    });
+    res.json({ success: true, id: result.key.id });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// React to a message
+app.post("/react", async (req, res) => {
+  try {
+    const { chatJid, messageId, emoji, remove } = req.body;
+    const result = await sock.sendMessage(chatJid, {
+      react: { text: remove ? "" : emoji, key: { remoteJid: chatJid, id: messageId } },
+    });
+    res.json({ success: true, id: result.key.id });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// Edit a message
+app.post("/edit", async (req, res) => {
+  try {
+    const { chatJid, messageId, message } = req.body;
+    const key = { remoteJid: chatJid, id: messageId, fromMe: true };
+    const result = await sock.sendMessage(chatJid, { text: message, edit: key });
+    res.json({ success: true, id: result.key.id });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// Unsend / delete a message
+app.post("/unsend", async (req, res) => {
+  try {
+    const { chatJid, messageId } = req.body;
+    const key = { remoteJid: chatJid, id: messageId, fromMe: true };
+    const result = await sock.sendMessage(chatJid, { delete: key });
+    res.json({ success: true });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// ── Group management ────────────────────────────────────────────────────────
+
+app.post("/group/create", async (req, res) => {
+  try {
+    const { name, participants } = req.body;
+    const jids = participants.map(toJid);
+    const result = await sock.groupCreate(name, jids);
+    res.json({ success: true, groupId: result.id });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+app.post("/group/rename", async (req, res) => {
+  try {
+    const { groupId, name } = req.body;
+    await sock.groupUpdateSubject(groupId, name);
+    res.json({ success: true });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+app.post("/group/description", async (req, res) => {
+  try {
+    const { groupId, description } = req.body;
+    await sock.groupUpdateDescription(groupId, description);
+    res.json({ success: true });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+app.post("/group/participants", async (req, res) => {
+  try {
+    const { groupId, participants, action } = req.body;
+    const jids = participants.map(toJid);
+    // action: "add" | "remove" | "promote" | "demote"
+    const result = await sock.groupParticipantsUpdate(groupId, jids, action);
+    res.json({ success: true, result });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+app.post("/group/invite-code", async (req, res) => {
+  try {
+    const { groupId } = req.body;
+    const code = await sock.groupInviteCode(groupId);
+    res.json({ success: true, link: `https://chat.whatsapp.com/${code}` });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+app.post("/group/revoke-invite", async (req, res) => {
+  try {
+    const { groupId } = req.body;
+    const code = await sock.groupRevokeInvite(groupId);
+    res.json({ success: true, link: `https://chat.whatsapp.com/${code}` });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+app.get("/group/info/:groupId", async (req, res) => {
+  try {
+    const info = await sock.groupMetadata(req.params.groupId);
+    res.json({ success: true, info });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+app.post("/group/leave", async (req, res) => {
+  try {
+    const { groupId } = req.body;
+    await sock.groupLeave(groupId);
+    res.json({ success: true });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+app.post("/group/icon", async (req, res) => {
+  try {
+    const { groupId, filePath } = req.body;
+    const buffer = fs.readFileSync(filePath);
+    await sock.updateProfilePicture(groupId, buffer);
+    res.json({ success: true });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function toJid(input) {
+  if (!input) throw new Error("recipient is required");
+  if (input.includes("@")) return input;
+  // Strip leading + and spaces
+  const num = input.replace(/[+\s-]/g, "");
+  return `${num}@s.whatsapp.net`;
+}
+
+// ── Start ───────────────────────────────────────────────────────────────────
+connectWhatsApp();
+app.listen(PORT, () => {
+  console.log(`Baileys bridge listening on port ${PORT}`);
+});

--- a/baileys-bridge/package.json
+++ b/baileys-bridge/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "baileys-bridge",
+  "version": "1.0.0",
+  "private": true,
+  "description": "WhatsApp Web bridge using Baileys — sidecar for Open Assistant",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@whiskeysockets/baileys": "^6.7.16",
+    "express": "^4.21.2",
+    "pino": "^9.6.0",
+    "qrcode-terminal": "^0.12.0"
+  }
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,12 +5,29 @@ services:
       - "${OA_WEBHOOK_PORT:-8080}:8080"
     env_file:
       - .env
+    environment:
+      - OA_BAILEYS_BRIDGE_URL=http://baileys:3100
     volumes:
       # Persist sessions and schedule config
       - assistant-data:/root/.open-assistant
       # Mount GWS credentials if using service account
       # - ./gws-credentials.json:/root/.config/gws/credentials.json:ro
+    depends_on:
+      - baileys
+    restart: unless-stopped
+
+  baileys:
+    build: ./baileys-bridge
+    ports:
+      - "${BAILEYS_PORT:-3100}:3100"
+    environment:
+      - BAILEYS_PORT=3100
+      - BAILEYS_CALLBACK_URL=http://assistant:8080/webhook/whatsapp/baileys
+      - BAILEYS_ACK_MESSAGE=${BAILEYS_ACK_MESSAGE:-}
+    volumes:
+      - baileys-auth:/app/auth_state
     restart: unless-stopped
 
 volumes:
   assistant-data:
+  baileys-auth:

--- a/src/channels/whatsapp.py
+++ b/src/channels/whatsapp.py
@@ -1,17 +1,18 @@
-"""WhatsApp channel adapter using Meta's Cloud API.
+"""WhatsApp channel adapter using Baileys bridge (WhatsApp Web protocol).
 
 Exposes a FastAPI router that:
-  1. Verifies the webhook during setup (GET).
-  2. Receives inbound messages (POST), forwards them to the Claude agent,
-     and sends the reply back via the Cloud API.
+  1. Receives inbound messages from the Baileys bridge sidecar (POST).
+  2. Forwards them to the Claude agent.
+  3. Sends replies back via the Baileys bridge REST API.
 """
 
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import httpx
-from fastapi import APIRouter, Query, Request, Response
+from fastapi import APIRouter, Request
 
 from src.agent.core import ask_agent
 from src.config import settings
@@ -20,61 +21,182 @@ log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/webhook/whatsapp", tags=["whatsapp"])
 
-GRAPH_API = "https://graph.facebook.com/v21.0"
+
+# ── Baileys bridge client ────────────────────────────────────────────────────
+
+def _bridge_url(path: str) -> str:
+    return f"{settings.baileys_bridge_url.rstrip('/')}{path}"
 
 
-# ── Webhook verification (GET) ─────────────────────────────────────────────
+async def _bridge_post(path: str, payload: dict) -> dict | None:
+    """POST to the Baileys bridge and return the JSON response."""
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(_bridge_url(path), json=payload)
+            if resp.status_code >= 400:
+                log.error("Bridge %s failed: %s %s", path, resp.status_code, resp.text)
+                return None
+            return resp.json()
+    except httpx.HTTPError as exc:
+        log.error("Bridge %s error: %s", path, exc)
+        return None
 
-@router.get("")
-async def verify(
-    hub_mode: str = Query(None, alias="hub.mode"),
-    hub_verify_token: str = Query(None, alias="hub.verify_token"),
-    hub_challenge: str = Query(None, alias="hub.challenge"),
-) -> Response:
-    if hub_mode == "subscribe" and hub_verify_token == settings.whatsapp_verify_token:
-        return Response(content=hub_challenge, media_type="text/plain")
-    return Response(status_code=403)
+
+# ── Outbound helpers ──────────────────────────────────────────────────────────
+
+async def send_text(to: str, message: str, quoted_id: str | None = None) -> dict | None:
+    """Send a text message via the Baileys bridge."""
+    payload: dict[str, Any] = {"to": to, "message": message[:65536]}
+    if quoted_id:
+        payload["quotedId"] = quoted_id
+    return await _bridge_post("/send/text", payload)
 
 
-# ── Inbound message (POST) ─────────────────────────────────────────────────
+async def send_media(
+    to: str,
+    file_path: str,
+    caption: str | None = None,
+    as_voice: bool = False,
+    gif_playback: bool = False,
+    mimetype: str | None = None,
+) -> dict | None:
+    """Send media (image, video, audio, document) via the Baileys bridge."""
+    payload: dict[str, Any] = {"to": to, "filePath": file_path}
+    if caption:
+        payload["caption"] = caption
+    if as_voice:
+        payload["asVoice"] = True
+    if gif_playback:
+        payload["gifPlayback"] = True
+    if mimetype:
+        payload["mimetype"] = mimetype
+    return await _bridge_post("/send/media", payload)
 
-@router.post("")
-async def inbound(request: Request) -> dict:
-    body = await request.json()
 
-    for entry in body.get("entry", []):
-        for change in entry.get("changes", []):
-            value = change.get("value", {})
-            for msg in value.get("messages", []):
-                if msg.get("type") != "text":
-                    continue
-                sender = msg["from"]
-                text = msg["text"]["body"]
-                log.info("whatsapp from=%s text=%s", sender, text[:80])
+async def send_sticker(to: str, file_path: str) -> dict | None:
+    """Send a sticker via the Baileys bridge."""
+    return await _bridge_post("/send/sticker", {"to": to, "filePath": file_path})
 
-                response = await ask_agent(text, chat_id=f"wa:{sender}")
-                await _send_text(sender, response)
+
+async def send_poll(
+    to: str, question: str, options: list[str], selectable_count: int = 0
+) -> dict | None:
+    """Send a poll via the Baileys bridge."""
+    return await _bridge_post("/send/poll", {
+        "to": to,
+        "question": question,
+        "options": options,
+        "selectableCount": selectable_count,
+    })
+
+
+async def react(
+    chat_jid: str, message_id: str, emoji: str = "", remove: bool = False
+) -> dict | None:
+    """Add or remove a reaction on a message."""
+    return await _bridge_post("/react", {
+        "chatJid": chat_jid,
+        "messageId": message_id,
+        "emoji": emoji,
+        "remove": remove,
+    })
+
+
+async def edit_message(chat_jid: str, message_id: str, message: str) -> dict | None:
+    """Edit a previously sent message."""
+    return await _bridge_post("/edit", {
+        "chatJid": chat_jid,
+        "messageId": message_id,
+        "message": message,
+    })
+
+
+async def unsend_message(chat_jid: str, message_id: str) -> dict | None:
+    """Delete/unsend a previously sent message."""
+    return await _bridge_post("/unsend", {
+        "chatJid": chat_jid,
+        "messageId": message_id,
+    })
+
+
+# ── Group management ─────────────────────────────────────────────────────────
+
+async def group_create(name: str, participants: list[str]) -> dict | None:
+    return await _bridge_post("/group/create", {"name": name, "participants": participants})
+
+
+async def group_rename(group_id: str, name: str) -> dict | None:
+    return await _bridge_post("/group/rename", {"groupId": group_id, "name": name})
+
+
+async def group_description(group_id: str, description: str) -> dict | None:
+    return await _bridge_post("/group/description", {"groupId": group_id, "description": description})
+
+
+async def group_participants(
+    group_id: str, participants: list[str], action: str
+) -> dict | None:
+    """Manage group participants. action: 'add' | 'remove' | 'promote' | 'demote'."""
+    return await _bridge_post("/group/participants", {
+        "groupId": group_id,
+        "participants": participants,
+        "action": action,
+    })
+
+
+async def group_invite_code(group_id: str) -> dict | None:
+    return await _bridge_post("/group/invite-code", {"groupId": group_id})
+
+
+async def group_revoke_invite(group_id: str) -> dict | None:
+    return await _bridge_post("/group/revoke-invite", {"groupId": group_id})
+
+
+async def group_leave(group_id: str) -> dict | None:
+    return await _bridge_post("/group/leave", {"groupId": group_id})
+
+
+async def group_icon(group_id: str, file_path: str) -> dict | None:
+    return await _bridge_post("/group/icon", {"groupId": group_id, "filePath": file_path})
+
+
+async def group_info(group_id: str) -> dict | None:
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(_bridge_url(f"/group/info/{group_id}"))
+            return resp.json() if resp.status_code < 400 else None
+    except httpx.HTTPError as exc:
+        log.error("Bridge group info error: %s", exc)
+        return None
+
+
+# ── Inbound message webhook (called by the Baileys bridge) ────────────────────
+
+@router.post("/baileys")
+async def inbound_from_bridge(request: Request) -> dict:
+    """Receive a message forwarded from the Baileys bridge sidecar."""
+    msg = await request.json()
+
+    sender = msg.get("from", "")
+    msg_type = msg.get("type", "unknown")
+    text = msg.get("text")
+    msg_id = msg.get("id")
+
+    # Only process text messages for now; media handling can be added later
+    if msg_type != "text" or not text:
+        log.debug("ignoring non-text message type=%s from=%s", msg_type, sender)
+        return {"status": "ignored"}
+
+    log.info("whatsapp from=%s text=%s", sender, text[:80])
+
+    response = await ask_agent(text, chat_id=f"wa:{sender}")
+    await send_text(sender, response, quoted_id=msg_id)
 
     return {"status": "ok"}
 
 
-# ── Outbound helper ────────────────────────────────────────────────────────
-
-async def _send_text(to: str, body: str) -> None:
-    url = f"{GRAPH_API}/{settings.whatsapp_phone_number_id}/messages"
-    headers = {"Authorization": f"Bearer {settings.whatsapp_access_token}"}
-    payload = {
-        "messaging_product": "whatsapp",
-        "to": to,
-        "type": "text",
-        "text": {"body": body[:4096]},
-    }
-    async with httpx.AsyncClient() as client:
-        resp = await client.post(url, json=payload, headers=headers)
-        if resp.status_code >= 400:
-            log.error("WhatsApp send failed: %s %s", resp.status_code, resp.text)
-
+# ── Public notification helper (used by scheduler) ───────────────────────────
 
 async def send_notification(to: str, body: str) -> None:
-    """Public helper for the scheduler to push proactive messages."""
-    await _send_text(to, body)
+    """Send a proactive message to a WhatsApp number or JID."""
+    await send_text(to, body)

--- a/src/config.py
+++ b/src/config.py
@@ -24,10 +24,8 @@ class Settings(BaseSettings):
     telegram_bot_token: str = ""
     telegram_allowed_users: list[str] = []  # usernames; empty = allow all
 
-    # --- WhatsApp (Meta Cloud API) ---
-    whatsapp_verify_token: str = ""
-    whatsapp_access_token: str = ""
-    whatsapp_phone_number_id: str = ""
+    # --- WhatsApp (Baileys bridge) ---
+    baileys_bridge_url: str = "http://localhost:3100"
 
     # --- Webhook server (for WhatsApp inbound) ---
     webhook_host: str = "0.0.0.0"


### PR DESCRIPTION
## Summary
- Switches WhatsApp channel from Meta Cloud API to **Baileys** (WhatsApp Web protocol) via a local Node.js bridge
- Adds `.claude/skills/whatsapp/SKILL.md` for WhatsApp skill discovery
- Adds `baileys-bridge/` — Dockerized Node.js service that speaks to `src/channels/whatsapp.py`
- Updates `docker-compose.yaml` to include the baileys-bridge service
- Updates `src/config.py` and `src/channels/whatsapp.py` for the new transport

## Test plan
- [ ] Baileys bridge connects successfully via QR code scan
- [ ] Incoming WhatsApp messages are routed to the agent
- [ ] Agent replies are delivered back via Baileys
- [ ] Docker Compose brings up both `open-assistant` and `baileys-bridge` together

🤖 Generated with [Claude Code](https://claude.com/claude-code)