### PR TITLE
feat: bi-directional memory sync with Google Drive

### DIFF
--- a/.claude/skills/memory/SKILL.md
+++ b/.claude/skills/memory/SKILL.md
@@ -5,16 +5,21 @@ description: Use when the user sends /memory, wants to see what the assistant kn
 
 # Memory Management
 
-Two-tier memory system: local files for fast access, GDrive for long-term archiving.
+Two-tier memory system: local files for fast access, GDrive for persistent shared storage.
 
 ## Tiers
 
 | Tier | Location | Purpose |
 |---|---|---|
 | Local | `~/.open-assistant/memory/` | Active context, read every session |
-| GDrive | `open_assistant/` folder at Drive root | Archive, long-term reference |
+| GDrive | `open_assistant/memory/` folder at Drive root | Shared persistent storage, synced automatically |
 
-Always start from local. Only touch GDrive when the user asks or when archiving.
+Memory is automatically synced between local and GDrive:
+- **On startup**: latest files are pulled from GDrive.
+- **Every 5 minutes**: bi-directional sync runs in the background.
+- **After writes**: always trigger a push (see SYNC AFTER WRITES below).
+
+This ensures multiple agent instances share the same memory.
 
 ---
 
@@ -43,3 +48,13 @@ Always start from local. Only touch GDrive when the user asks or when archiving.
 - If GDrive `open_assistant/` folder exists: upload archived content as `archive-[topic].md` in that folder, then remove archived entries from the local file.
 - If no GDrive: move content to a `## Archive` section at the bottom of the local file.
 - Confirm what was moved and where.
+
+---
+
+## SYNC AFTER WRITES
+
+**After every write to a memory file** (update, add, or archive), run:
+```bash
+python -c "import asyncio; from src.memory.sync import push; asyncio.run(push(['FILENAME.md']))"
+```
+Replace `FILENAME.md` with the file(s) that were modified. This ensures other agent instances see the change immediately rather than waiting for the next periodic sync.

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ service-account*.json
 # Scratch / download files
 download.html
 
-# Memory files — keep only the example
-memory/
-!memory/example/
+# Runtime memory data (the ~/.open-assistant/memory/ volume)
+# Don't ignore src/memory/ (sync module) or .claude/skills/memory/ (skill)
+**/memory/*.md
+!.claude/skills/memory/SKILL.md

--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,7 @@ from fastapi import FastAPI
 
 from src.channels.whatsapp import router as whatsapp_router
 from src.config import settings
-from src.memory.sync import pull as memory_pull, sync as memory_sync
+from src.memory.sync import pull as memory_pull
 from src.scheduler.scheduler import start_scheduler
 
 logging.basicConfig(
@@ -29,25 +29,7 @@ def _create_api() -> FastAPI:
     async def health() -> dict:
         return {"status": "ok"}
 
-    @app.post("/memory/sync")
-    async def memory_sync_endpoint() -> dict:
-        """Trigger an immediate bi-directional memory sync."""
-        results = await memory_sync()
-        return {"status": "ok", "results": results}
-
     return app
-
-
-async def _periodic_memory_sync(interval: int = 300) -> None:
-    """Background task: bi-directional memory sync every *interval* seconds."""
-    while True:
-        await asyncio.sleep(interval)
-        try:
-            results = await memory_sync()
-            if any(v not in ("pull:up-to-date",) for v in results.values()):
-                log.info("periodic memory sync: %s", results)
-        except Exception:
-            log.warning("periodic memory sync failed", exc_info=True)
 
 
 async def _run() -> None:
@@ -63,9 +45,6 @@ async def _run() -> None:
     scheduler = start_scheduler()
 
     tasks: list[asyncio.Task] = []
-
-    # Background memory sync (every 5 minutes)
-    tasks.append(asyncio.create_task(_periodic_memory_sync()))
 
     # 2. Start the webhook server (for WhatsApp inbound)
     api = _create_api()

--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI
 
 from src.channels.whatsapp import router as whatsapp_router
 from src.config import settings
+from src.memory.sync import pull as memory_pull, sync as memory_sync
 from src.scheduler.scheduler import start_scheduler
 
 logging.basicConfig(
@@ -28,14 +29,43 @@ def _create_api() -> FastAPI:
     async def health() -> dict:
         return {"status": "ok"}
 
+    @app.post("/memory/sync")
+    async def memory_sync_endpoint() -> dict:
+        """Trigger an immediate bi-directional memory sync."""
+        results = await memory_sync()
+        return {"status": "ok", "results": results}
+
     return app
 
 
+async def _periodic_memory_sync(interval: int = 300) -> None:
+    """Background task: bi-directional memory sync every *interval* seconds."""
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            results = await memory_sync()
+            if any(v not in ("pull:up-to-date",) for v in results.values()):
+                log.info("periodic memory sync: %s", results)
+        except Exception:
+            log.warning("periodic memory sync failed", exc_info=True)
+
+
 async def _run() -> None:
+    # 0. Pull latest memory from GDrive before anything else
+    try:
+        pull_results = await memory_pull()
+        if pull_results:
+            log.info("startup memory pull: %s", pull_results)
+    except Exception:
+        log.warning("startup memory pull failed — continuing with local files", exc_info=True)
+
     # 1. Start the scheduler (cron tasks)
     scheduler = start_scheduler()
 
     tasks: list[asyncio.Task] = []
+
+    # Background memory sync (every 5 minutes)
+    tasks.append(asyncio.create_task(_periodic_memory_sync()))
 
     # 2. Start the webhook server (for WhatsApp inbound)
     api = _create_api()

--- a/src/memory/sync.py
+++ b/src/memory/sync.py
@@ -1,0 +1,343 @@
+"""Bi-directional sync between local memory files and Google Drive.
+
+On startup every agent instance pulls the latest memory from GDrive into the
+local ``~/.open-assistant/memory/`` directory.  After any local write the
+changed file is pushed back so that other agent instances (or a future
+container) see the update immediately.
+
+Conflict resolution: **last-write-wins** using GDrive ``modifiedTime``.
+Each file is compared individually — only files that are newer on the remote
+side overwrite local copies during pull, and vice-versa during push.
+
+Requires the ``gws`` CLI (Google Workspace CLI) to be installed and
+authenticated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from src.config import settings
+
+log = logging.getLogger(__name__)
+
+MEMORY_DIR = Path.home() / ".open-assistant" / "memory"
+SYNC_META = MEMORY_DIR / ".sync-meta.json"
+
+# GDrive folder name at drive root
+_GDRIVE_FOLDER = "open_assistant"
+# Subfolder inside GDrive folder for active memory
+_GDRIVE_MEMORY_SUBFOLDER = "memory"
+
+
+# ---------------------------------------------------------------------------
+# Low-level helpers
+# ---------------------------------------------------------------------------
+
+
+async def _run_gws(*args: str, timeout: float = 30) -> tuple[int, str, str]:
+    """Run a ``gws`` CLI command and return (returncode, stdout, stderr)."""
+    cmd = [settings.gws_binary, *args]
+    log.debug("gws command: %s", " ".join(cmd))
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        return -1, "", "timeout"
+    return proc.returncode, stdout_b.decode(), stderr_b.decode()
+
+
+def _load_sync_meta() -> dict[str, str]:
+    """Return ``{filename: iso_modified_time}`` from the local sync metadata."""
+    if SYNC_META.exists():
+        try:
+            return json.loads(SYNC_META.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {}
+
+
+def _save_sync_meta(meta: dict[str, str]) -> None:
+    SYNC_META.parent.mkdir(parents=True, exist_ok=True)
+    SYNC_META.write_text(json.dumps(meta, indent=2) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# GDrive folder resolution
+# ---------------------------------------------------------------------------
+
+
+async def _find_folder_id(name: str, parent_id: str | None = None) -> str | None:
+    """Return the GDrive file-id of a folder by *name*, optionally under *parent_id*."""
+    q = f'name="{name}" and mimeType="application/vnd.google-apps.folder" and trashed=false'
+    if parent_id:
+        q += f' and "{parent_id}" in parents'
+    rc, out, err = await _run_gws(
+        "drive", "files", "list",
+        "--params", json.dumps({"q": q, "pageSize": 1, "fields": "files(id,name)"}),
+    )
+    if rc != 0:
+        log.warning("gws drive files list failed: %s", err)
+        return None
+    try:
+        data = json.loads(out)
+        files = data.get("files", [])
+        return files[0]["id"] if files else None
+    except (json.JSONDecodeError, KeyError, IndexError):
+        return None
+
+
+async def _ensure_folder(name: str, parent_id: str | None = None) -> str | None:
+    """Return the id of folder *name*, creating it if necessary."""
+    fid = await _find_folder_id(name, parent_id)
+    if fid:
+        return fid
+    # Create the folder
+    metadata: dict[str, object] = {
+        "name": name,
+        "mimeType": "application/vnd.google-apps.folder",
+    }
+    if parent_id:
+        metadata["parents"] = [parent_id]
+    rc, out, err = await _run_gws(
+        "drive", "files", "create",
+        "--params", json.dumps({"fields": "id"}),
+        "--data", json.dumps(metadata),
+    )
+    if rc != 0:
+        log.error("failed to create folder %s: %s", name, err)
+        return None
+    try:
+        return json.loads(out).get("id")
+    except (json.JSONDecodeError, KeyError):
+        return None
+
+
+async def _get_memory_folder_id() -> str | None:
+    """Resolve (or create) ``open_assistant/memory/`` on GDrive and return its id."""
+    root_id = await _ensure_folder(_GDRIVE_FOLDER)
+    if not root_id:
+        return None
+    return await _ensure_folder(_GDRIVE_MEMORY_SUBFOLDER, parent_id=root_id)
+
+
+# ---------------------------------------------------------------------------
+# List remote memory files
+# ---------------------------------------------------------------------------
+
+
+async def _list_remote_files(folder_id: str) -> list[dict]:
+    """Return list of ``{id, name, modifiedTime}`` for files in *folder_id*."""
+    q = f'"{folder_id}" in parents and trashed=false'
+    rc, out, err = await _run_gws(
+        "drive", "files", "list",
+        "--params", json.dumps({
+            "q": q,
+            "pageSize": 50,
+            "fields": "files(id,name,modifiedTime)",
+        }),
+    )
+    if rc != 0:
+        log.warning("listing remote memory files failed: %s", err)
+        return []
+    try:
+        return json.loads(out).get("files", [])
+    except (json.JSONDecodeError, KeyError):
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Download / Upload
+# ---------------------------------------------------------------------------
+
+
+async def _download_file(file_id: str, dest: Path) -> bool:
+    """Download a GDrive file by *file_id* to *dest*."""
+    rc, out, err = await _run_gws(
+        "drive", "files", "export",
+        "--fileId", file_id,
+        "--mimeType", "text/plain",
+        "--dest", str(dest),
+    )
+    if rc != 0:
+        # Try get (for non-Google-Docs files)
+        rc, out, err = await _run_gws(
+            "drive", "files", "get",
+            "--fileId", file_id,
+            "--dest", str(dest),
+        )
+    return rc == 0
+
+
+async def _upload_file(local_path: Path, folder_id: str, existing_id: str | None = None) -> str | None:
+    """Upload *local_path* to GDrive. Update in-place if *existing_id* given.
+
+    Returns the file id on success, None on failure.
+    """
+    if existing_id:
+        # Update existing file
+        rc, out, err = await _run_gws(
+            "drive", "files", "update",
+            "--fileId", existing_id,
+            "--file", str(local_path),
+        )
+    else:
+        # Create new file in the folder
+        metadata = json.dumps({"name": local_path.name, "parents": [folder_id]})
+        rc, out, err = await _run_gws(
+            "drive", "files", "create",
+            "--data", metadata,
+            "--file", str(local_path),
+            "--params", json.dumps({"fields": "id"}),
+        )
+    if rc != 0:
+        log.error("upload failed for %s: %s", local_path.name, err)
+        return None
+    try:
+        return json.loads(out).get("id", existing_id)
+    except (json.JSONDecodeError, KeyError):
+        return existing_id
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def pull(*, force: bool = False) -> dict[str, str]:
+    """Pull memory files from GDrive → local.  Returns ``{filename: action}``."""
+    MEMORY_DIR.mkdir(parents=True, exist_ok=True)
+    folder_id = await _get_memory_folder_id()
+    if not folder_id:
+        log.warning("GDrive memory folder not available — skipping pull")
+        return {}
+
+    remote_files = await _list_remote_files(folder_id)
+    if not remote_files:
+        log.info("no remote memory files found")
+        return {}
+
+    meta = _load_sync_meta()
+    results: dict[str, str] = {}
+
+    for rf in remote_files:
+        name = rf["name"]
+        remote_modified = rf.get("modifiedTime", "")
+        local_path = MEMORY_DIR / name
+
+        # Decide whether to download
+        if not force and local_path.exists():
+            last_synced = meta.get(name, "")
+            if last_synced and remote_modified <= last_synced:
+                results[name] = "up-to-date"
+                continue
+
+        ok = await _download_file(rf["id"], local_path)
+        if ok:
+            meta[name] = remote_modified
+            results[name] = "pulled"
+            log.info("pulled %s from GDrive", name)
+        else:
+            results[name] = "error"
+            log.error("failed to pull %s", name)
+
+    _save_sync_meta(meta)
+    return results
+
+
+async def push(files: list[str] | None = None) -> dict[str, str]:
+    """Push local memory files → GDrive.  If *files* is None, push all ``.md`` files."""
+    folder_id = await _get_memory_folder_id()
+    if not folder_id:
+        log.warning("GDrive memory folder not available — skipping push")
+        return {}
+
+    if files is None:
+        files = [p.name for p in MEMORY_DIR.glob("*.md")]
+
+    # Build lookup of existing remote files
+    remote_files = await _list_remote_files(folder_id)
+    remote_by_name: dict[str, dict] = {rf["name"]: rf for rf in remote_files}
+
+    meta = _load_sync_meta()
+    results: dict[str, str] = {}
+
+    for name in files:
+        local_path = MEMORY_DIR / name
+        if not local_path.exists():
+            results[name] = "missing"
+            continue
+
+        existing = remote_by_name.get(name)
+        fid = await _upload_file(local_path, folder_id, existing_id=existing["id"] if existing else None)
+        if fid:
+            now_iso = datetime.now(timezone.utc).isoformat()
+            meta[name] = now_iso
+            results[name] = "pushed"
+            log.info("pushed %s to GDrive", name)
+        else:
+            results[name] = "error"
+
+    _save_sync_meta(meta)
+    return results
+
+
+async def sync() -> dict[str, str]:
+    """Full bi-directional sync: pull then push.
+
+    Pull brings remote-only or remote-newer files down.
+    Push sends local-only or local-newer files up.
+    """
+    results: dict[str, str] = {}
+
+    # 1. Pull remote → local (remote wins if newer)
+    pull_results = await pull()
+    for name, action in pull_results.items():
+        results[name] = f"pull:{action}"
+
+    # 2. Push local → remote (pushes files not yet on remote or modified locally)
+    folder_id = await _get_memory_folder_id()
+    if not folder_id:
+        return results
+
+    remote_files = await _list_remote_files(folder_id)
+    remote_by_name = {rf["name"]: rf for rf in remote_files}
+    meta = _load_sync_meta()
+
+    local_files = list(MEMORY_DIR.glob("*.md"))
+    to_push: list[str] = []
+    for lf in local_files:
+        name = lf.name
+        if name not in remote_by_name:
+            # Local-only file → push
+            to_push.append(name)
+        else:
+            # Compare local mtime vs last sync time
+            local_mtime = datetime.fromtimestamp(lf.stat().st_mtime, tz=timezone.utc).isoformat()
+            last_synced = meta.get(name, "")
+            if not last_synced or local_mtime > last_synced:
+                to_push.append(name)
+
+    if to_push:
+        push_results = await push(to_push)
+        for name, action in push_results.items():
+            results[name] = f"push:{action}"
+
+    return results
+
+
+async def is_gdrive_available() -> bool:
+    """Quick check whether GDrive is reachable and authenticated."""
+    folder_id = await _find_folder_id(_GDRIVE_FOLDER)
+    return folder_id is not None

--- a/tests/test_memory_sync.py
+++ b/tests/test_memory_sync.py
@@ -1,0 +1,222 @@
+"""Tests for src.memory.sync — GDrive ↔ local memory synchronisation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.memory.sync import (
+    MEMORY_DIR,
+    SYNC_META,
+    _load_sync_meta,
+    _save_sync_meta,
+    is_gdrive_available,
+    pull,
+    push,
+    sync,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_FOLDER_ID = "folder_abc123"
+FAKE_MEMORY_FOLDER_ID = "folder_mem456"
+
+
+def _mock_gws_folder_lookup(name: str, parent_id: str | None = None):
+    """Return a mock gws response for folder lookups."""
+    if name == "open_assistant" and parent_id is None:
+        return (0, json.dumps({"files": [{"id": FAKE_FOLDER_ID, "name": "open_assistant"}]}), "")
+    if name == "memory" and parent_id == FAKE_FOLDER_ID:
+        return (0, json.dumps({"files": [{"id": FAKE_MEMORY_FOLDER_ID, "name": "memory"}]}), "")
+    return (0, json.dumps({"files": []}), "")
+
+
+# ---------------------------------------------------------------------------
+# Sync metadata persistence
+# ---------------------------------------------------------------------------
+
+
+def test_sync_meta_roundtrip(tmp_path, monkeypatch):
+    meta_file = tmp_path / ".sync-meta.json"
+    monkeypatch.setattr("src.memory.sync.SYNC_META", meta_file)
+    monkeypatch.setattr("src.memory.sync.MEMORY_DIR", tmp_path)
+
+    data = {"index.md": "2026-01-01T00:00:00+00:00", "projects.md": "2026-01-02T00:00:00+00:00"}
+    _save_sync_meta(data)
+    assert meta_file.exists()
+    loaded = _load_sync_meta()
+    assert loaded == data
+
+
+def test_load_sync_meta_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr("src.memory.sync.SYNC_META", tmp_path / "nope.json")
+    assert _load_sync_meta() == {}
+
+
+def test_load_sync_meta_corrupt(tmp_path, monkeypatch):
+    meta_file = tmp_path / ".sync-meta.json"
+    meta_file.write_text("not json!")
+    monkeypatch.setattr("src.memory.sync.SYNC_META", meta_file)
+    assert _load_sync_meta() == {}
+
+
+# ---------------------------------------------------------------------------
+# is_gdrive_available
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gdrive_available_true():
+    async def fake_run(*args, **kw):
+        return (0, json.dumps({"files": [{"id": "x", "name": "open_assistant"}]}), "")
+
+    with patch("src.memory.sync._run_gws", side_effect=fake_run):
+        assert await is_gdrive_available() is True
+
+
+@pytest.mark.asyncio
+async def test_gdrive_available_false():
+    async def fake_run(*args, **kw):
+        return (0, json.dumps({"files": []}), "")
+
+    with patch("src.memory.sync._run_gws", side_effect=fake_run):
+        assert await is_gdrive_available() is False
+
+
+# ---------------------------------------------------------------------------
+# pull
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pull_skips_when_no_gdrive(tmp_path, monkeypatch):
+    monkeypatch.setattr("src.memory.sync.MEMORY_DIR", tmp_path)
+
+    with patch("src.memory.sync._get_memory_folder_id", return_value=None):
+        result = await pull()
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_pull_downloads_new_file(tmp_path, monkeypatch):
+    monkeypatch.setattr("src.memory.sync.MEMORY_DIR", tmp_path)
+    monkeypatch.setattr("src.memory.sync.SYNC_META", tmp_path / ".sync-meta.json")
+
+    remote_files = [{"id": "file1", "name": "index.md", "modifiedTime": "2026-03-01T00:00:00Z"}]
+
+    async def fake_download(file_id, dest):
+        dest.write_text("# Index\n")
+        return True
+
+    with (
+        patch("src.memory.sync._get_memory_folder_id", return_value=FAKE_MEMORY_FOLDER_ID),
+        patch("src.memory.sync._list_remote_files", return_value=remote_files),
+        patch("src.memory.sync._download_file", side_effect=fake_download),
+    ):
+        result = await pull()
+
+    assert result == {"index.md": "pulled"}
+    assert (tmp_path / "index.md").read_text() == "# Index\n"
+
+
+@pytest.mark.asyncio
+async def test_pull_skips_up_to_date(tmp_path, monkeypatch):
+    monkeypatch.setattr("src.memory.sync.MEMORY_DIR", tmp_path)
+    monkeypatch.setattr("src.memory.sync.SYNC_META", tmp_path / ".sync-meta.json")
+
+    # Local file exists and meta says it's already synced
+    (tmp_path / "index.md").write_text("# Index\n")
+    _save_sync_meta_at = tmp_path / ".sync-meta.json"
+    _save_sync_meta_at.write_text(json.dumps({"index.md": "2026-03-01T00:00:00Z"}))
+
+    remote_files = [{"id": "file1", "name": "index.md", "modifiedTime": "2026-03-01T00:00:00Z"}]
+
+    with (
+        patch("src.memory.sync._get_memory_folder_id", return_value=FAKE_MEMORY_FOLDER_ID),
+        patch("src.memory.sync._list_remote_files", return_value=remote_files),
+    ):
+        result = await pull()
+
+    assert result == {"index.md": "up-to-date"}
+
+
+# ---------------------------------------------------------------------------
+# push
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_push_uploads_file(tmp_path, monkeypatch):
+    monkeypatch.setattr("src.memory.sync.MEMORY_DIR", tmp_path)
+    monkeypatch.setattr("src.memory.sync.SYNC_META", tmp_path / ".sync-meta.json")
+
+    (tmp_path / "index.md").write_text("# Index\n")
+
+    async def fake_upload(local_path, folder_id, existing_id=None):
+        return "new_file_id"
+
+    with (
+        patch("src.memory.sync._get_memory_folder_id", return_value=FAKE_MEMORY_FOLDER_ID),
+        patch("src.memory.sync._list_remote_files", return_value=[]),
+        patch("src.memory.sync._upload_file", side_effect=fake_upload),
+    ):
+        result = await push(["index.md"])
+
+    assert result == {"index.md": "pushed"}
+
+
+@pytest.mark.asyncio
+async def test_push_skips_missing_file(tmp_path, monkeypatch):
+    monkeypatch.setattr("src.memory.sync.MEMORY_DIR", tmp_path)
+    monkeypatch.setattr("src.memory.sync.SYNC_META", tmp_path / ".sync-meta.json")
+
+    with (
+        patch("src.memory.sync._get_memory_folder_id", return_value=FAKE_MEMORY_FOLDER_ID),
+        patch("src.memory.sync._list_remote_files", return_value=[]),
+    ):
+        result = await push(["nonexistent.md"])
+
+    assert result == {"nonexistent.md": "missing"}
+
+
+@pytest.mark.asyncio
+async def test_push_skips_when_no_gdrive(tmp_path, monkeypatch):
+    monkeypatch.setattr("src.memory.sync.MEMORY_DIR", tmp_path)
+
+    with patch("src.memory.sync._get_memory_folder_id", return_value=None):
+        result = await push(["index.md"])
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# full sync
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_pulls_then_pushes(tmp_path, monkeypatch):
+    monkeypatch.setattr("src.memory.sync.MEMORY_DIR", tmp_path)
+    monkeypatch.setattr("src.memory.sync.SYNC_META", tmp_path / ".sync-meta.json")
+
+    # Local file that's not on remote
+    (tmp_path / "local-only.md").write_text("local\n")
+
+    pull_mock = AsyncMock(return_value={"remote.md": "pulled"})
+    push_mock = AsyncMock(return_value={"local-only.md": "pushed"})
+
+    with (
+        patch("src.memory.sync.pull", pull_mock),
+        patch("src.memory.sync._get_memory_folder_id", return_value=FAKE_MEMORY_FOLDER_ID),
+        patch("src.memory.sync._list_remote_files", return_value=[]),
+        patch("src.memory.sync.push", push_mock),
+    ):
+        result = await sync()
+
+    assert "remote.md" in result
+    pull_mock.assert_awaited_once()


### PR DESCRIPTION
## Summary

- **New `src/memory/sync.py` module** — bi-directional sync between local `~/.open-assistant/memory/` (Docker volume) and GDrive `open_assistant/memory/` folder using the `gws` CLI
- **Startup pull** — on boot, the agent pulls the latest memory files from GDrive before processing any messages
- **Periodic background sync** — every 5 minutes, a background task runs full bi-directional sync (pull remote-newer, push local-newer)
- **POST `/memory/sync` endpoint** — allows triggering an immediate sync via API
- **Updated memory skill** — instructs the agent to push after every memory write so other instances see changes immediately
- **12 unit tests** covering metadata persistence, pull/push/sync logic, and GDrive availability checks

This enables multiple agent containers to share the same memory — each instance pulls on startup and pushes after writes, with last-write-wins conflict resolution.

## Test plan

- [x] All 12 new tests in `tests/test_memory_sync.py` pass
- [ ] Deploy with GDrive credentials mounted and verify startup pull logs
- [ ] Write to memory via `/memory update` and confirm file appears in GDrive
- [ ] Spin up a second container and verify it pulls the updated memory on startup

https://claude.ai/code/session_014fL7ju1zw5bBZryBydL8iV